### PR TITLE
bug of crashing in old fonts API

### DIFF
--- a/src/measure.coffee
+++ b/src/measure.coffee
@@ -58,8 +58,11 @@ measureCharWidth = (text, style) ->
 
 # very tricky, as fonts loaded, cache is outdated
 # http://stackoverflow.com/a/32292880/883571
-document?.fonts?.ready.then ->
-  widthCaches = {}
+# also make sure it does break in Gulp
+# and .ready is a promise, has compatibility issues
+if (typeof window isnt 'undefined') and document.fonts?
+  document.fonts.ready?.then? ->
+    widthCaches = {}
 
 measureTextWidth = (text, style) ->
   width = 0


### PR DESCRIPTION
低版本的 IE 等完全不支持 fonts API, 旧代码能正确识别.
某些版本的 Chrome Firefox 实现部分的 fonts API, 旧代码无法正确识别, 加载代码报错.
增加一些判断
